### PR TITLE
Add graphql dependency

### DIFF
--- a/packages/sanity-plugin/package.json
+++ b/packages/sanity-plugin/package.json
@@ -47,7 +47,7 @@
 		"url": "https://github.com/good-idea/sane-shopify/issues"
 	},
 	"peerDependencies": {
-		"graphql": "^14.5.8",
+		"graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0",
 		"react": "16.2",
 		"react-dom": "16.2"
 	},

--- a/packages/sanity-plugin/package.json
+++ b/packages/sanity-plugin/package.json
@@ -47,6 +47,7 @@
 		"url": "https://github.com/good-idea/sane-shopify/issues"
 	},
 	"peerDependencies": {
+		"graphql": "^14.5.8",
 		"react": "16.2",
 		"react-dom": "16.2"
 	},
@@ -84,7 +85,6 @@
 		"@sanity/base": "^0.144.1",
 		"@sanity/components": "^0.144.2",
 		"@sanity/form-builder": "^0.144.2",
-		"graphql": "^14.5.8",
 		"lodash": "^4.17.15",
 		"lodash-es": "^4.17.15",
 		"ramda": "^0.26.1",

--- a/packages/sanity-plugin/package.json
+++ b/packages/sanity-plugin/package.json
@@ -84,6 +84,7 @@
 		"@sanity/base": "^0.144.1",
 		"@sanity/components": "^0.144.2",
 		"@sanity/form-builder": "^0.144.2",
+		"graphql": "^14.5.8",
 		"lodash": "^4.17.15",
 		"lodash-es": "^4.17.15",
 		"ramda": "^0.26.1",


### PR DESCRIPTION
Sanity studio complained until I added this - I guess maybe it could be a peer dependency but `graphql-tag` needs it