### PR TITLE
Change storefront token to plain text field

### DIFF
--- a/packages/sanity-plugin/src/ShopifyTool/Setup.tsx
+++ b/packages/sanity-plugin/src/ShopifyTool/Setup.tsx
@@ -157,7 +157,7 @@ export class SetupBase extends React.Component<ClientContextValue, State> {
                 disabled={success || loading}
                 onChange={this.handleInputChange('accessToken')}
                 value={accessToken}
-                type="password"
+                type="text"
               />
             </FormField>
           </React.Fragment>


### PR DESCRIPTION
Hehe this is pretty minor : )

> Storefront API access tokens are not secret. You can place them in a JavaScript file or any public HTML document.