### PR TITLE
docs(server): update to "roll your own" code example

### DIFF
--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -181,7 +181,7 @@ import { webhooks } from './src/webhooks'
 
 app.post('/api/onProductCreate', async (req, res) => {
   const { body } = req;
-  await webhooks[webhook](body);
+  await webhooks.onProductCreate(body)
   res.status(200).send('success')
 })
 ```

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -180,8 +180,8 @@ An example express.js route might be:
 import { webhooks } from './src/webhooks'
 
 app.post('/api/onProductCreate', async (req, res) => {
-  const id = req.body.id
-  await webhooks.onProductCreate(id)
+  const { body } = req;
+  await webhooks[webhook](body);
   res.status(200).send('success')
 })
 ```


### PR DESCRIPTION
closes: #132

I've updated the code example in the documentation so that the argument passed to the webhook handler is the object the handler is expecting rather than the `id` string. 

I haven't updated the `WebhookData` typing but the shape of WebhookData which the webhook is expecting and the shape of the request body do have differences.