### PR TITLE
feat(sync-utils): set document ID in Sanity to match shopifyId

### DIFF
--- a/packages/sync-utils/src/sanity/syncSanityDocument.ts
+++ b/packages/sync-utils/src/sanity/syncSanityDocument.ts
@@ -41,6 +41,7 @@ const mergeExistingFields = (
     const options = docInfo.options || []
     const doc: SanityShopifyProductDocumentPartial = {
       ...merged,
+      _id: existingDoc._id,
       sourceData: {
         ...docInfo.sourceData,
         collections: {

--- a/packages/sync-utils/src/sanity/utils.ts
+++ b/packages/sync-utils/src/sanity/utils.ts
@@ -182,11 +182,12 @@ export const prepareDocument = <T extends Product | Collection>(
 
     const productDocInfo: SanityShopifyProductDocumentPartial = {
       _type,
+      shopifyId: item.id,
+      _id: item.id.replace(/=/g, ''),
       archived: false,
       minVariantPrice,
       maxVariantPrice,
       title: item.title,
-      shopifyId: item.id,
       handle: item.handle,
       sourceData: {
         ...sourceData,

--- a/packages/types/src/types/sanity.ts
+++ b/packages/types/src/types/sanity.ts
@@ -38,7 +38,7 @@ export type SanityShopifyDocumentPartial =
 
 export type SanityShopifyProductDocumentPartial = Omit<
   SanityShopifyProductDocument,
-  '_id' | 'collections'
+  'collections'
 >
 export type SanityShopifyCollectionDocumentPartial = Omit<
   SanityShopifyCollectionDocument,


### PR DESCRIPTION
closes #165

This commit sets the document ID in Sanity for newly created documents to be the same as the ShopifyID.

The only difference between the ID's is the `=` from the ShopifyID is removed as this fails validation on Sanity's end.

Existing documents are not changed.

Doing this allows us to use the `IDFilter` when performing a `ShopifyProduct` query on Sanity using GraphQl with an ID returned directly from Shopify, for example when loading a users checkout.

It would make sense to handle Collection ID's in the same way. Happy to create a PR for that too.