### PR TITLE
fix(sync-utils): fix duplicate product references in collections

### DIFF
--- a/packages/sync-utils/src/sanity/config.ts
+++ b/packages/sync-utils/src/sanity/config.ts
@@ -34,7 +34,7 @@ export const createClearConfig = (
   client: SanityClient
 ): SanityUtils['clearConfig'] => async (shopName: string) => {
   const configDoc = await client.fetch<SaneShopifyConfigDocument>(
-    `[_type == $type && shopName == $shopName]`,
+    `*[_type == $type && shopName == $shopName][0]`,
     { type: CONFIG_DOC_TYPE, shopName }
   )
   if (!configDoc) {

--- a/packages/sync-utils/src/sanity/fetchAll.ts
+++ b/packages/sync-utils/src/sanity/fetchAll.ts
@@ -18,6 +18,7 @@ export const createFetchAll = (
   const allDocs = await client.fetch<SanityShopifyDocument[]>(`
   *[
     shopifyId != null &&
+    !(_id in path('drafts.**')) &&
     (${typesFilter})
    ]{
       products[]->{

--- a/packages/sync-utils/src/sanity/fetchRelatedDocs.ts
+++ b/packages/sync-utils/src/sanity/fetchRelatedDocs.ts
@@ -43,7 +43,7 @@ export const createFetchRelatedDocs = (
   const fetched = idsNotInCache.length
     ? await client.fetch<SanityShopifyDocument[]>(
         `
-    *[shopifyId in $relatedIds && defined(archived) && archived != true]{
+    *[shopifyId in $relatedIds && defined(archived) && archived != true && !(_id in path('drafts.**'))]{
       products[]->{
         "collectionRefs": collections[],
         ...

--- a/packages/sync-utils/src/sanity/sanityUtils.ts
+++ b/packages/sync-utils/src/sanity/sanityUtils.ts
@@ -87,8 +87,8 @@ export const sanityUtils = (
     shopifyClient
   )
   const fetchRelatedDocs = createFetchRelatedDocs(client, cache)
-  const syncRelationships = createSyncRelationships(client)
-  const removeRelationships = createRemoveRelationships(client)
+  const syncRelationships = createSyncRelationships(client, cache)
+  const removeRelationships = createRemoveRelationships(client, cache)
   const archiveSanityDocument = createArchiveSanityDocument(client)
   const clearConfig = createClearConfig(client)
   const saveConfig = createSaveConfig(client)
@@ -99,7 +99,7 @@ export const sanityUtils = (
     if (cached) return cached
 
     const doc = await client.fetch<SanityShopifyDocument>(
-      `*[shopifyId == $shopifyId && defined(archived) && archived != true]{
+      `*[shopifyId == $shopifyId && defined(archived) && archived != true && !(_id in path('drafts.**'))]{
         products[]->{
           "collectionRefs": collections[],
           ...
@@ -125,7 +125,7 @@ export const sanityUtils = (
     if (cached) return cached
 
     const doc = await client.fetch<SanityShopifyDocument>(
-      `*[handle == $handle && defined(archived) && archived != true]{
+      `*[handle == $handle && defined(archived) && archived != true && !(_id in path('drafts.**'))]{
         products[]->{
           "collectionRefs": collections[],
           ...

--- a/packages/sync-utils/src/sanity/syncSanityDocument.ts
+++ b/packages/sync-utils/src/sanity/syncSanityDocument.ts
@@ -186,9 +186,7 @@ export const createSyncSanityDocument = (
 
     /* Create a new document if none exists */
     if (!existingDoc) {
-      const newDoc = await client.createIfNotExists<SanityShopifyDocumentPartial>(
-        docInfo
-      )
+      const newDoc = await client.create<SanityShopifyDocumentPartial>(docInfo)
       const refetchedDoc = await getSanityDocByShopifyId(newDoc.shopifyId)
       if (!refetchedDoc) {
         throw new Error(

--- a/packages/sync-utils/src/utils.ts
+++ b/packages/sync-utils/src/utils.ts
@@ -77,7 +77,7 @@ export const buildProductReferences = async (
 ): Promise<ProductRef[]> => {
   const [productNodes] = unwindEdges(products)
   const productIds = productNodes.map((node) => node.id)
-  const query = '*[_type == "shopifyProduct" && shopifyId in $productIds]'
+  const query = `*[_type == "shopifyProduct" && shopifyId in $productIds && !(_id in path('drafts.**'))]`
   const productDocuments = await sanityClient.fetch<
     SanityShopifyProductDocument[]
   >(query, { productIds })


### PR DESCRIPTION
+ fix check to see if documents are linked
+ avoid fetching drafts

Fixes #164